### PR TITLE
Explicit urban vars

### DIFF
--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -835,12 +835,12 @@ state    real   LF_URB2D_S     ij       misc      1        -     i01r     "LF_UR
 state    real   AHE            i{m_hr}j  misc       1        -     i01r   "AHE"        "Anthropogenic heat emission" "W m-2"
 
 # Additional urban model parameters - PK2025
-state    real   ALBR_URB2D       ij  misc      1        -     irh       "ALBR_URB2D"   "surface albedo of roof" "-"
-state    real   ALBB_URB2D       ij  misc      1        -     irh       "ALBB_URB2D"   "surface albedo of building wall" "-"
-state    real   ALBG_URB2D       ij  misc      1        -     irh       "ALBG_URB2D"   "surface albedo of road" "-"
-state    real   EPSR_URB2D       ij  misc      1        -     irh       "EPSR_URB2D"   "surface emissivity of roof" "-"
-state    real   EPSB_URB2D       ij  misc      1        -     irh       "EPSB_URB2D"   "surface emissivity of building wall" "-"
-state    real   EPSG_URB2D       ij  misc      1        -     irh       "EPSG_URB2D"   "surface emissivity of road" "-"
+state    real   ALBR_URB2D     ij       misc      1        -     i012rh   "ALBR_URB2D"   "surface albedo of roof" "-"
+state    real   ALBB_URB2D     ij       misc      1        -     i012rh   "ALBB_URB2D"   "surface albedo of building wall" "-"
+state    real   ALBG_URB2D     ij       misc      1        -     i012rh   "ALBG_URB2D"   "surface albedo of road" "-"
+state    real   EPSR_URB2D     ij       misc      1        -     i012rh   "EPSR_URB2D"   "surface emissivity of roof" "-"
+state    real   EPSB_URB2D     ij       misc      1        -     i012rh   "EPSB_URB2D"   "surface emissivity of building wall" "-"
+state    real   EPSG_URB2D     ij       misc      1        -     i012rh   "EPSG_URB2D"   "surface emissivity of road" "-"
 
 # lsm State Variables
 

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -834,6 +834,14 @@ state    real   LF_URB2D_S     ij       misc      1        -     i01r     "LF_UR
 # AHE with month and hour dimension flattened to one dimension, Jan = (0:23), Feb = (24:47)
 state    real   AHE            i{m_hr}j  misc       1        -     i01r   "AHE"        "Anthropogenic heat emission" "W m-2"
 
+# Additional urban model parameters - PK2025
+state    real   ALBR_URB2D       ij  misc      1        -     irh       "ALBR_URB2D"   "surface albedo of roof" "-"
+state    real   ALBB_URB2D       ij  misc      1        -     irh       "ALBB_URB2D"   "surface albedo of building wall" "-"
+state    real   ALBG_URB2D       ij  misc      1        -     irh       "ALBG_URB2D"   "surface albedo of road" "-"
+state    real   EPSR_URB2D       ij  misc      1        -     irh       "EPSR_URB2D"   "surface emissivity of roof" "-"
+state    real   EPSB_URB2D       ij  misc      1        -     irh       "EPSB_URB2D"   "surface emissivity of building wall" "-"
+state    real   EPSG_URB2D       ij  misc      1        -     irh       "EPSG_URB2D"   "surface emissivity of road" "-"
+
 # lsm State Variables
 
 state    real   SMOIS            ilj     -          1         Z     i02rhd=(interp_mask_field:lu_index,iswater)u=(copy_fcnm)    "SMOIS"            "SOIL MOISTURE"     "m3 m-3"

--- a/Registry/Registry.EM_COMMON
+++ b/Registry/Registry.EM_COMMON
@@ -835,12 +835,12 @@ state    real   LF_URB2D_S     ij       misc      1        -     i01r     "LF_UR
 state    real   AHE            i{m_hr}j  misc       1        -     i01r   "AHE"        "Anthropogenic heat emission" "W m-2"
 
 # Additional urban model parameters - PK2025
-state    real   ALBR_URB2D     ij       misc      1        -     i012rh   "ALBR_URB2D"   "surface albedo of roof" "-"
-state    real   ALBB_URB2D     ij       misc      1        -     i012rh   "ALBB_URB2D"   "surface albedo of building wall" "-"
-state    real   ALBG_URB2D     ij       misc      1        -     i012rh   "ALBG_URB2D"   "surface albedo of road" "-"
-state    real   EPSR_URB2D     ij       misc      1        -     i012rh   "EPSR_URB2D"   "surface emissivity of roof" "-"
-state    real   EPSB_URB2D     ij       misc      1        -     i012rh   "EPSB_URB2D"   "surface emissivity of building wall" "-"
-state    real   EPSG_URB2D     ij       misc      1        -     i012rh   "EPSG_URB2D"   "surface emissivity of road" "-"
+state    real   ALBR_URB2D     ij       misc      1        -     i01h   "ALBR_URB2D"   "surface albedo of roof" "-"
+state    real   ALBB_URB2D     ij       misc      1        -     i01h   "ALBB_URB2D"   "surface albedo of building wall" "-"
+state    real   ALBG_URB2D     ij       misc      1        -     i01h   "ALBG_URB2D"   "surface albedo of road" "-"
+state    real   EPSR_URB2D     ij       misc      1        -     i01h   "EPSR_URB2D"   "surface emissivity of roof" "-"
+state    real   EPSB_URB2D     ij       misc      1        -     i01h   "EPSB_URB2D"   "surface emissivity of building wall" "-"
+state    real   EPSG_URB2D     ij       misc      1        -     i01h   "EPSG_URB2D"   "surface emissivity of road" "-"
 
 # lsm State Variables
 
@@ -2560,6 +2560,8 @@ rconfig   real    convtrans_avglen_m      namelist,physics      1             30
 rconfig   integer num_land_cat            namelist,physics	1            21       -      "num_land_cat"                  ""      ""
 rconfig   integer use_wudapt_lcz          namelist,physics      1             0       -      "use_wudapt_lcz"                ""      ""
 rconfig   logical slucm_distributed_drag  namelist,physics      1          .false.    rh      "slucm_distributed_drag"                ""      ""
+rconfig   character urb2d_additional_vars namelist,physics      6            ""      -     "additional explicit urban parameters. Comma-separated list of the following variables: ALBB, ALBR, ALBG, EPSB, EPSR, EPSG."
+rconfig   integer num_urb2d_additional_vars namelist,physics    1            0      -      "number of additional explicit urban parameters supplied for the namelist option urb2d_additional_vars."
 rconfig   integer distributed_ahe_opt     namelist,physics      1            0        rh     "distributed_ahe_opt" "AHE handling: 0= no AHE, 1=add to first level temperature tendency, 2=add to surface sensible heat flux" ""
 rconfig   integer num_soil_cat            namelist,physics	1            16       -      "num_soil_cat"                  ""      ""
 rconfig   integer mp_zero_out             namelist,physics	1             0       -      "mp_zero_out"  "microphysics fields set to zero  0=no action taken, 1=all fields but Qv, 2=all fields including Qv"      "flag"

--- a/dyn_em/module_first_rk_step_part1.F
+++ b/dyn_em/module_first_rk_step_part1.F
@@ -777,6 +777,9 @@ BENCH_START(surf_driver_tim)
      &        ,TG_URB2D=grid%tg_urb2d                                     & !H urban
      &        ,TC_URB2D=grid%tc_urb2d ,QC_URB2D=grid%qc_urb2d             & !H urban
      &        ,UC_URB2D=grid%uc_urb2d                                     & !H urban
+     &        ,albr_urb2d=grid%albr_urb2d, albb_urb2d=grid%albb_urb2d     & !I urban explicit radiation PK2025
+     &        ,albg_urb2d=grid%albg_urb2d, epsr_urb2d=grid%epsr_urb2d     & !I urban explicit radiation PK2025
+     &        ,epsb_urb2d=grid%epsb_urb2d, epsg_urb2d=grid%epsg_urb2d     & !I urban explicit radiation PK2025
      &        ,XXXR_URB2D=grid%xxxr_urb2d                                 &
      &        ,XXXB_URB2D=grid%xxxb_urb2d                                 & !H urban
      &        ,XXXG_URB2D=grid%xxxg_urb2d                                 &

--- a/phys/module_sf_clm.F
+++ b/phys/module_sf_clm.F
@@ -58802,6 +58802,8 @@ CONTAINS
                 cmcr_urb2d,tgr_urb2d,tgrl_urb3d,smr_urb3d,      & ! urban
                 drelr_urb2d,drelb_urb2d,drelg_urb2d,            & ! urban
                 flxhumr_urb2d,flxhumb_urb2d,flxhumg_urb2d,      &
+                albr_urb2d, albb_urb2d, albg_urb2d,             & !I explicit radiation PK2025
+                epsr_urb2d, epsb_urb2d, epsg_urb2d,             & !I explicit radiation PK2025
 ! subgrids
                numc,nump,sabv,sabg,lwup,snl, &
                 snowdp,wtc,wtp,h2osno,t_grnd,t_veg,         &
@@ -59228,6 +59230,15 @@ CONTAINS
      REAL, DIMENSION(1:num_road_layers) :: TGL_URB  ! road layer temp [K]
      LOGICAL  :: LSOLAR_URB
      
+!  Explicit radiation parameters PK2025
+     real :: albr_urb,albb_urb,albg_urb,epsr_urb,epsb_urb,epsg_urb
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: albr_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: albb_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: albg_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: epsr_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: epsb_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: epsg_urb2d
+
 !===Yang,2014/10/08,hydrological variable for single layer UCM===
      INTEGER :: jmonth, jday
      REAL :: DRELR_URB
@@ -60326,6 +60337,14 @@ has_urban_physics : &
             lf_urb_s = 0
             z0_urb = 0
             vegfrac = 0
+! Explicit radiation parameters PK2025
+            ! x = merge(ifTrue, ifFalse, Condition)
+            albr_urb = merge(ALBR_URB2D(I,J), -999., present(ALBR_URB2D))
+            albb_urb = merge(ALBB_URB2D(I,J), -999., present(ALBB_URB2D))
+            albg_urb = merge(ALBG_URB2D(I,J), -999., present(ALBG_URB2D))
+            epsr_urb = merge(EPSR_URB2D(I,J), -999., present(EPSR_URB2D))
+            epsb_urb = merge(EPSB_URB2D(I,J), -999., present(EPSB_URB2D))
+            epsg_urb = merge(EPSG_URB2D(I,J), -999., present(EPSG_URB2D))
 !
 
 ! Call urban
@@ -60351,7 +60370,10 @@ has_urban_physics : &
                        UST_URB,mh_urb, stdh_urb, lf_urb, lp_urb,        & ! 0
 !sw++
 !                      hgt_urb,frc_urb,lb_urb, check)
-                       hgt_urb,frc_urb,lb_urb, check,CMCR_URB,TGR_URB,  & ! H
+                       hgt_urb,frc_urb,lb_urb, check,                   & ! H
+                       albr_urb, albb_urb,albg_urb,                     & ! I
+                       epsr_urb,epsb_urb,epsg_urb,                      & ! I
+                       CMCR_URB,TGR_URB,                                & ! H
                        TGRL_URB,SMR_URB,CMGR_URB, CHGR_URB, jmonth,     & ! H
                        DRELR_URB,DRELB_URB,                             & ! H
                        DRELG_URB,FLXHUMR_URB,FLXHUMB_URB,FLXHUMG_URB,   &

--- a/phys/module_sf_clm.F
+++ b/phys/module_sf_clm.F
@@ -60338,13 +60338,12 @@ has_urban_physics : &
             z0_urb = 0
             vegfrac = 0
 ! Explicit radiation parameters PK2025
-            ! x = merge(ifTrue, ifFalse, Condition)
-            albr_urb = merge(ALBR_URB2D(I,J), -999., present(ALBR_URB2D))
-            albb_urb = merge(ALBB_URB2D(I,J), -999., present(ALBB_URB2D))
-            albg_urb = merge(ALBG_URB2D(I,J), -999., present(ALBG_URB2D))
-            epsr_urb = merge(EPSR_URB2D(I,J), -999., present(EPSR_URB2D))
-            epsb_urb = merge(EPSB_URB2D(I,J), -999., present(EPSB_URB2D))
-            epsg_urb = merge(EPSG_URB2D(I,J), -999., present(EPSG_URB2D))
+            albr_urb = albr_urb2d(i,j)
+            albb_urb = albb_urb2d(i,j)
+            albg_urb = albg_urb2d(i,j)
+            epsr_urb = epsr_urb2d(i,j)
+            epsb_urb = epsb_urb2d(i,j)
+            epsg_urb = epsg_urb2d(i,j)
 !
 
 ! Call urban

--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -68,6 +68,8 @@ CONTAINS
 !Optional Urban
                   TR_URB2D,TB_URB2D,TG_URB2D,TC_URB2D,QC_URB2D, & !H urban
                   UC_URB2D,                                     & !H urban
+                  albr_urb2d, albb_urb2d, albg_urb2d,           & !I urban explicit radiation PK2025
+                  epsr_urb2d, epsb_urb2d, epsg_urb2d,           & !I urban explicit radiation PK2025
                   XXXR_URB2D,XXXB_URB2D,XXXG_URB2D,XXXC_URB2D,  & !H urban
                   TRL_URB3D,TBL_URB3D,TGL_URB3D,                & !H urban
                   SH_URB2D,LH_URB2D,G_URB2D,RN_URB2D,TS_URB2D,  & !H urban
@@ -503,6 +505,15 @@ CONTAINS
      REAL, DIMENSION(1:num_wall_layers) :: TBL_URB  ! wall layer temp [K]
      REAL, DIMENSION(1:num_road_layers) :: TGL_URB  ! road layer temp [K]
      LOGICAL  :: LSOLAR_URB
+
+!  Explicit radiation parameters PK2025
+     real :: albr_urb,albb_urb,albg_urb,epsr_urb,epsb_urb,epsg_urb
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: albr_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: albb_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: albg_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: epsr_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: epsb_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: epsg_urb2d
 
 !===Yang,2014/10/08,hydrological variable for single layer UCM===
      INTEGER :: jmonth, jday, tloc
@@ -1428,6 +1439,16 @@ CONTAINS
             z0_urb = z0_urb2d(I, J)
             vegfrac = vegfra(I, J) / 100
 !
+! Explicit radiation parameters PK2025
+            ! x = merge(ifTrue, ifFalse, Condition)
+            albr_urb = merge(albr_urb2d(i,j), -999., present(albr_urb2d))
+            albb_urb = merge(albb_urb2d(i,j), -999., present(albb_urb2d))
+            albg_urb = merge(albg_urb2d(i,j), -999., present(albg_urb2d))
+            epsr_urb = merge(epsr_urb2d(i,j), -999., present(epsr_urb2d))
+            epsb_urb = merge(epsb_urb2d(i,j), -999., present(epsb_urb2d))
+            epsg_urb = merge(epsg_urb2d(i,j), -999., present(epsg_urb2d))
+!
+!
 ! Call urban
             CALL cal_mon_day(julian,julyr,jmonth,jday)
             CALL urban(LSOLAR_URB,                                      & ! I
@@ -1447,7 +1468,10 @@ CONTAINS
                        CMR_URB, CHR_URB, CMC_URB, CHC_URB,              &
                        U10_URB, V10_URB, TH2_URB, Q2_URB,               & ! O
                        UST_URB,mh_urb, stdh_urb, lf_urb, lp_urb,        & ! 0
-                       hgt_urb,frc_urb,lb_urb, check,CMCR_URB,TGR_URB,  & ! H
+                       hgt_urb,frc_urb,lb_urb,                          & ! H
+                       albr_urb, albb_urb,albg_urb,                     & ! I
+                       epsr_urb,epsb_urb,epsg_urb,                      & ! I
+                       check,CMCR_URB,TGR_URB,                          & ! H
                        TGRL_URB,SMR_URB,CMGR_URB,CHGR_URB,jmonth,       & ! H
                        DRELR_URB,DRELB_URB,                             & ! H
                        DRELG_URB,FLXHUMR_URB,FLXHUMB_URB,FLXHUMG_URB,   &
@@ -2390,6 +2414,8 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
 !Optional Urban
                   TR_URB2D,TB_URB2D,TG_URB2D,TC_URB2D,QC_URB2D, & !H urban
                   UC_URB2D,                                     & !H urban
+                  albr_urb2d, albb_urb2d, albg_urb2d,           & !I urban explicit radiation PK2025
+                  epsr_urb2d, epsb_urb2d, epsg_urb2d,           & !I urban explicit radiation PK2025
                   XXXR_URB2D,XXXB_URB2D,XXXG_URB2D,XXXC_URB2D,  & !H urban
                   TRL_URB3D,TBL_URB3D,TGL_URB3D,                & !H urban
                   SH_URB2D,LH_URB2D,G_URB2D,RN_URB2D,TS_URB2D,  & !H urban
@@ -2835,6 +2861,15 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
      REAL, DIMENSION(1:num_wall_layers) :: TBL_URB  ! wall layer temp [K]
      REAL, DIMENSION(1:num_road_layers) :: TGL_URB  ! road layer temp [K]
      LOGICAL  :: LSOLAR_URB
+
+!  Explicit radiation parameters PK2025
+     real :: albr_urb,albb_urb,albg_urb,epsr_urb,epsb_urb,epsg_urb
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: albr_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: albb_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: albg_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: epsr_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: epsb_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: epsg_urb2d
 
 !===Yang,2014/10/08,hydrological variable for single layer UCM===
      INTEGER :: jmonth, jday, tloc
@@ -3883,6 +3918,15 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   lf_urb_s = lf_urb2d_s(I, J)
                   z0_urb = z0_urb2d(I, J)
                   vegfrac = vegfra(I, J) / 100.
+      ! Explicit radiation parameters PK2025
+                  ! x = merge(ifTrue, ifFalse, Condition)
+                  albr_urb = merge(albr_urb2d(i,j), -999., present(albr_urb2d))
+                  albb_urb = merge(albb_urb2d(i,j), -999., present(albb_urb2d))
+                  albg_urb = merge(albg_urb2d(i,j), -999., present(albg_urb2d))
+                  epsr_urb = merge(epsr_urb2d(i,j), -999., present(epsr_urb2d))
+                  epsb_urb = merge(epsb_urb2d(i,j), -999., present(epsb_urb2d))
+                  epsg_urb = merge(epsg_urb2d(i,j), -999., present(epsg_urb2d))
+!
       !
       ! Call urban
                   CALL cal_mon_day(julian,julyr,jmonth,jday)      
@@ -3903,7 +3947,10 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                              CMR_URB, CHR_URB, CMC_URB, CHC_URB,              &
                              U10_URB, V10_URB, TH2_URB, Q2_URB,               & ! O
                              UST_URB,mh_urb, stdh_urb, lf_urb, lp_urb,        & ! 0
-                             hgt_urb,frc_urb,lb_urb, check,CMCR_URB,TGR_URB,  & ! H
+                             hgt_urb,frc_urb,lb_urb,                          & ! H
+                             albr_urb, albb_urb,albg_urb,                     & ! I
+                             epsr_urb,epsb_urb,epsg_urb,                      & ! I
+                             check,CMCR_URB,TGR_URB,                          & ! H
                              TGRL_URB,SMR_URB,CMGR_URB,CHGR_URB,jmonth,       & ! H
                              DRELR_URB,DRELB_URB,                             & ! H
                              DRELG_URB,FLXHUMR_URB,FLXHUMB_URB,FLXHUMG_URB,   &
@@ -4762,7 +4809,15 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   lf_urb_s = lf_urb2d_s(I, J)
                   z0_urb = z0_urb2d(I, J)
                   vegfrac = vegfra(I, J) / 100.0
-
+      ! Explicit radiation parameters PK2025
+                  ! x = merge(ifTrue, ifFalse, Condition)
+                  albr_urb = merge(albr_urb2d(i,j), -999., present(albr_urb2d))
+                  albb_urb = merge(albb_urb2d(i,j), -999., present(albb_urb2d))
+                  albg_urb = merge(albg_urb2d(i,j), -999., present(albg_urb2d))
+                  epsr_urb = merge(epsr_urb2d(i,j), -999., present(epsr_urb2d))
+                  epsb_urb = merge(epsb_urb2d(i,j), -999., present(epsb_urb2d))
+                  epsg_urb = merge(epsg_urb2d(i,j), -999., present(epsg_urb2d))
+!
       !
       ! Call urban
                   CALL cal_mon_day(julian,julyr,jmonth,jday)        
@@ -4783,7 +4838,10 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                              CMR_URB, CHR_URB, CMC_URB, CHC_URB,              &
                              U10_URB, V10_URB, TH2_URB, Q2_URB,               & ! O
                              UST_URB,mh_urb, stdh_urb, lf_urb, lp_urb,        & ! 0
-                             hgt_urb,frc_urb,lb_urb, check,CMCR_URB,TGR_URB,  & ! H
+                             hgt_urb,frc_urb,lb_urb,                          & ! H
+                             albr_urb, albb_urb,albg_urb,                     & ! I
+                             epsr_urb,epsb_urb,epsg_urb,                      & ! I
+                             check,CMCR_URB,TGR_URB,                          & ! H
                              TGRL_URB,SMR_URB,CMGR_URB,CHGR_URB,jmonth,       & ! H
                              DRELR_URB,DRELB_URB,                             & ! H
                              DRELG_URB,FLXHUMR_URB,FLXHUMB_URB,FLXHUMG_URB,   &

--- a/phys/module_sf_noahdrv.F
+++ b/phys/module_sf_noahdrv.F
@@ -1440,14 +1440,12 @@ CONTAINS
             vegfrac = vegfra(I, J) / 100
 !
 ! Explicit radiation parameters PK2025
-            ! x = merge(ifTrue, ifFalse, Condition)
-            albr_urb = merge(albr_urb2d(i,j), -999., present(albr_urb2d))
-            albb_urb = merge(albb_urb2d(i,j), -999., present(albb_urb2d))
-            albg_urb = merge(albg_urb2d(i,j), -999., present(albg_urb2d))
-            epsr_urb = merge(epsr_urb2d(i,j), -999., present(epsr_urb2d))
-            epsb_urb = merge(epsb_urb2d(i,j), -999., present(epsb_urb2d))
-            epsg_urb = merge(epsg_urb2d(i,j), -999., present(epsg_urb2d))
-!
+            albr_urb = albr_urb2d(i,j)
+            albb_urb = albb_urb2d(i,j)
+            albg_urb = albg_urb2d(i,j)
+            epsr_urb = epsr_urb2d(i,j)
+            epsb_urb = epsb_urb2d(i,j)
+            epsg_urb = epsg_urb2d(i,j)
 !
 ! Call urban
             CALL cal_mon_day(julian,julyr,jmonth,jday)
@@ -3919,13 +3917,12 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   z0_urb = z0_urb2d(I, J)
                   vegfrac = vegfra(I, J) / 100.
       ! Explicit radiation parameters PK2025
-                  ! x = merge(ifTrue, ifFalse, Condition)
-                  albr_urb = merge(albr_urb2d(i,j), -999., present(albr_urb2d))
-                  albb_urb = merge(albb_urb2d(i,j), -999., present(albb_urb2d))
-                  albg_urb = merge(albg_urb2d(i,j), -999., present(albg_urb2d))
-                  epsr_urb = merge(epsr_urb2d(i,j), -999., present(epsr_urb2d))
-                  epsb_urb = merge(epsb_urb2d(i,j), -999., present(epsb_urb2d))
-                  epsg_urb = merge(epsg_urb2d(i,j), -999., present(epsg_urb2d))
+                  albr_urb = albr_urb2d(i,j)
+                  albb_urb = albb_urb2d(i,j)
+                  albg_urb = albg_urb2d(i,j)
+                  epsr_urb = epsr_urb2d(i,j)
+                  epsb_urb = epsb_urb2d(i,j)
+                  epsg_urb = epsg_urb2d(i,j)
 !
       !
       ! Call urban
@@ -4810,14 +4807,13 @@ SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
                   z0_urb = z0_urb2d(I, J)
                   vegfrac = vegfra(I, J) / 100.0
       ! Explicit radiation parameters PK2025
-                  ! x = merge(ifTrue, ifFalse, Condition)
-                  albr_urb = merge(albr_urb2d(i,j), -999., present(albr_urb2d))
-                  albb_urb = merge(albb_urb2d(i,j), -999., present(albb_urb2d))
-                  albg_urb = merge(albg_urb2d(i,j), -999., present(albg_urb2d))
-                  epsr_urb = merge(epsr_urb2d(i,j), -999., present(epsr_urb2d))
-                  epsb_urb = merge(epsb_urb2d(i,j), -999., present(epsb_urb2d))
-                  epsg_urb = merge(epsg_urb2d(i,j), -999., present(epsg_urb2d))
-!
+                  albr_urb = albr_urb2d(i,j)
+                  albb_urb = albb_urb2d(i,j)
+                  albg_urb = albg_urb2d(i,j)
+                  epsr_urb = epsr_urb2d(i,j)
+                  epsb_urb = epsb_urb2d(i,j)
+                  epsg_urb = epsg_urb2d(i,j)
+      !
       !
       ! Call urban
                   CALL cal_mon_day(julian,julyr,jmonth,jday)        

--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -289,6 +289,7 @@ USE module_model_constants, ONLY :  piconst
 !     Kusaka et al. (2001) Bound.-Layer Meteor., vol.101, p329-358
 !
 ! History:
+!     2025/11,         modified by Peter Kalverla (NL eScience Center)   
 !     2014/10,         modified by Jiachuan Yang (ASU)
 !     2006/06          modified by H. Kusaka (Univ. Tsukuba), M. Tewari 
 !     2005/10/26,      modified by Fei Chen, Mukul Tewari
@@ -317,6 +318,8 @@ USE module_model_constants, ONLY :  piconst
                     CMR_URB,CHR_URB,CMC_URB,CHC_URB,                  & ! I/O
                     U10,V10,TH2,Q2,UST,mh_urb,stdh_urb,lf_urb,        & ! O 
                     lp_urb,hgt_urb,frc_urb,lb_urb,zo_check,           & ! O
+                    albr_urb, albb_urb,albg_urb,                      & ! I
+                    epsr_urb,epsb_urb,epsg_urb,                       & ! I
                     CMCR,TGR,TGRL,SMR,CMGR_URB,CHGR_URB,jmonth,       & ! H
                     DRELR,DRELB,DRELG,FLXHUMR,FLXHUMB,FLXHUMG,        &
                     lf_urb_s, z0_urb, vegfrac_in)
@@ -399,7 +402,15 @@ USE module_model_constants, ONLY :  piconst
    REAL, INTENT(INOUT) :: lb_urb   ! building surface to plan area ratio [-]
    REAL, INTENT(INOUT), DIMENSION(4) :: lf_urb   ! frontal area index [-]
    REAL, INTENT(INOUT) :: zo_check  ! check for printing ZOC
-
+!-------------------------------------------------------------------------------
+! I: Additional spatially explicit urban model parameters - PK2025
+!-------------------------------------------------------------------------------
+  REAL, INTENT(IN) :: albr_urb   ! surface albedo of roof [-]
+  REAL, INTENT(IN) :: albb_urb   ! surface albedo of building wall [-]
+  REAL, INTENT(IN) :: albg_urb   ! surface albedo of road [-]
+  REAL, INTENT(IN) :: epsr_urb   ! surface emissivity of roof [-]
+  REAL, INTENT(IN) :: epsb_urb   ! surface emissivity of building wall [-]
+  REAL, INTENT(IN) :: epsg_urb   ! surface emissivity of road [-]
 !-------------------------------------------------------------------------------
 ! I: Distributed aerodynamics parameters
 !-------------------------------------------------------------------------------
@@ -789,6 +800,13 @@ USE module_model_constants, ONLY :  piconst
 
  !End NUDAPT Modification
 
+! PK2025, use spatially explicit radiation parameters if provided
+if (albr_urb /= -999.) ALBR=albr_urb
+if (albb_urb /= -999.) ALBB=albb_urb
+if (albg_urb /= -999.) ALBG=albg_urb
+if (epsr_urb /= -999.) EPSR=epsr_urb
+if (epsb_urb /= -999.) EPSB=epsb_urb
+if (epsg_urb /= -999.) EPSG=epsg_urb
 
 ! Miao, 2007/01/17, cal. ah
    if(ahoption==1) AH=AH*ahdiuprf(tloc)
@@ -2740,7 +2758,7 @@ ENDIF
       LH_URB2D(I,J)=0.
       G_URB2D(I,J)=0.
       RN_URB2D(I,J)=0.
-      
+
 !m
 !FS   FRC_URB2D(I,J)=0.
       UTYPE_URB2D(I,J)=0

--- a/phys/module_sf_urban.F
+++ b/phys/module_sf_urban.F
@@ -8,7 +8,7 @@ use module_wrf_error
 #define FATAL_ERROR(M) call wrf_error_fatal( M )
 #define WRITE_MESSAGE(M) call wrf_message( M )
 #endif
-
+USE module_configure
 USE module_model_constants, ONLY :  piconst
 
 !===============================================================================
@@ -411,6 +411,9 @@ USE module_model_constants, ONLY :  piconst
   REAL, INTENT(IN) :: epsr_urb   ! surface emissivity of roof [-]
   REAL, INTENT(IN) :: epsb_urb   ! surface emissivity of building wall [-]
   REAL, INTENT(IN) :: epsg_urb   ! surface emissivity of road [-]
+  CHARACTER(len=32) :: extra_var_name
+  INTEGER :: n_extra_vars
+
 !-------------------------------------------------------------------------------
 ! I: Distributed aerodynamics parameters
 !-------------------------------------------------------------------------------
@@ -801,12 +804,26 @@ USE module_model_constants, ONLY :  piconst
  !End NUDAPT Modification
 
 ! PK2025, use spatially explicit radiation parameters if provided
-if (albr_urb /= -999.) ALBR=albr_urb
-if (albb_urb /= -999.) ALBB=albb_urb
-if (albg_urb /= -999.) ALBG=albg_urb
-if (epsr_urb /= -999.) EPSR=epsr_urb
-if (epsb_urb /= -999.) EPSB=epsb_urb
-if (epsg_urb /= -999.) EPSG=epsg_urb
+ CALL nl_get_num_urb2d_additional_vars(1, n_extra_vars) 
+ do iteration = 1, n_extra_vars
+   CALL nl_get_urb2d_additional_vars(iteration, extra_var_name) 
+   select case(trim(extra_var_name))
+   case('ALBB')
+      if (albb_urb /= -999.) ALBB=albb_urb
+   case('ALBR')
+      if (albr_urb /= -999.) ALBR=albr_urb
+   case('ALBG')
+      if (albg_urb /= -999.) ALBG=albg_urb
+   case('EPSB')
+      if (epsb_urb /= -999.) EPSB=epsb_urb
+   case('EPSR')
+      if (epsr_urb /= -999.) EPSR=epsr_urb
+   case('EPSG')
+      if (epsg_urb /= -999.) EPSG=epsg_urb
+   case default
+       write(*,*) 'WARNING: Unknown urb2d additional variable: ', trim(extra_var_name)
+   end select
+end do
 
 ! Miao, 2007/01/17, cal. ah
    if(ahoption==1) AH=AH*ahdiuprf(tloc)

--- a/phys/module_surface_driver.F
+++ b/phys/module_surface_driver.F
@@ -187,6 +187,8 @@ CONTAINS
      &          ,num_road_layers, dzr, dzb, dzg                       & !I urban
      &          ,tr_urb2d,tb_urb2d,tg_urb2d,tc_urb2d,qc_urb2d         & !H urban
      &          ,uc_urb2d                                             & !H urban
+     &          ,albr_urb2d, albb_urb2d, albg_urb2d                   & !I urban explicit radiation PK2025
+     &          ,epsr_urb2d, epsb_urb2d, epsg_urb2d                   & !I urban explicit radiation PK2025
      &          ,xxxr_urb2d,xxxb_urb2d,xxxg_urb2d,xxxc_urb2d          & !H urban
      &          ,cmcr_urb2d,tgr_urb2d,tgrl_urb3d,smr_urb3d            & !H urban
      &          ,julian,julyr,drelr_urb2d,drelb_urb2d,drelg_urb2d     & !H urban
@@ -1288,6 +1290,14 @@ CONTAINS
      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT):: XXXB_URB2D !urban
      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT):: XXXG_URB2D !urban
      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT):: XXXC_URB2D !urban
+
+!  Explicit radiation parameters PK2025
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: albr_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: albb_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: albg_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: epsr_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: epsb_urb2d
+     real, optional, dimension( ims:ime, jms:jme ), intent(in) :: epsg_urb2d
 
      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: DRELR_URB2D
      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: DRELB_URB2D
@@ -2706,6 +2716,8 @@ CONTAINS
                 ,cmgr_sfcdif,chgr_sfcdif                        &
                 ,tr_urb2d,tb_urb2d,tg_urb2d,tc_urb2d,qc_urb2d,  & !H urban
                 uc_urb2d,                                       & !H urban
+                albr_urb2d, albb_urb2d, albg_urb2d,             & !I urban explicit radiation PK2025
+                epsr_urb2d, epsb_urb2d, epsg_urb2d,             & !I urban explicit radiation PK2025
                 xxxr_urb2d,xxxb_urb2d,xxxg_urb2d,xxxc_urb2d,    & !H urban
                 trl_urb3d,tbl_urb3d,tgl_urb3d,                  & !H urban
                 sh_urb2d,lh_urb2d,g_urb2d,rn_urb2d,ts_urb2d,    & !H urban
@@ -2850,6 +2862,8 @@ CONTAINS
                 ,cmgr_sfcdif,chgr_sfcdif                        &
                 ,tr_urb2d,tb_urb2d,tg_urb2d,tc_urb2d,qc_urb2d,  & !H urban
                 uc_urb2d,                                       & !H urban
+                albr_urb2d, albb_urb2d, albg_urb2d,             & !I urban explicit radiation PK2025
+                epsr_urb2d, epsb_urb2d, epsg_urb2d,             & !I urban explicit radiation PK2025
                 xxxr_urb2d,xxxb_urb2d,xxxg_urb2d,xxxc_urb2d,    & !H urban
                 trl_urb3d,tbl_urb3d,tgl_urb3d,                  & !H urban
                 sh_urb2d,lh_urb2d,g_urb2d,rn_urb2d,ts_urb2d,    & !H urban
@@ -3231,6 +3245,8 @@ CONTAINS
                            lp_urb2d,       hi_urb2d,       lb_urb2d,  hgt_urb2d,            & !H multi-layer urban
                            mh_urb2d,     stdh_urb2d,       lf_urb2d,                        & !SLUCM
                          lf_urb2d_s,       z0_urb2d,         vegfra,                        & !SLUCM
+                         albr_urb2d,     albb_urb2d,     albg_urb2d,                        & !I urban explicit radiation PK2025
+                         epsr_urb2d,     epsb_urb2d,     epsg_urb2d,                        & !I urban explicit radiation PK2025
                              th_phy,            rho,          p_phy,        ust,            & !I multi-layer urban
                                 gmt,         julday,          xlong,       xlat,            & !I multi-layer urban
                             a_u_bep,        a_v_bep,        a_t_bep,    a_q_bep,            & !O multi-layer urban
@@ -3805,6 +3821,8 @@ CONTAINS
                 cmcr_urb2d,tgr_urb2d,tgrl_urb3d,smr_urb3d,      & ! urban
                 drelr_urb2d,drelb_urb2d,drelg_urb2d,            & ! urban
                 flxhumr_urb2d,flxhumb_urb2d,flxhumg_urb2d,      &
+                albr_urb2d, albb_urb2d, albg_urb2d,             & !I explicit radiation PK2025
+                epsr_urb2d, epsb_urb2d, epsg_urb2d,             & !I explicit radiation PK2025
 ! CLM subgrids
                 numc,nump,sabv,sabg,lwup,snl, &
                 snowdp,wtc,wtp,h2osno,t_grnd,t_veg,         &


### PR DESCRIPTION
Add spatially explicit radiation parameters to SLUCM

TYPE: new feature

KEYWORDS: slucm, 2d fields, radiation, albedo, emissivity

SOURCE: Peter Kalverla (Netherlands eScience Center)

DESCRIPTION OF CHANGES:
Problem:
Currently, urban albedo and emissivity can only be provided per urban class. We are investigating methods to obtain spatially explicit radiation fields and want to assess its impact in WRF.

Solution:
We added 6 parameters to the model code that are propagated into the land surface schemes and eventually the urban scheme. See attached for details: [urban_flow.pdf](https://github.com/user-attachments/files/23661226/urban_flow3.pdf)

LIST OF MODIFIED FILES: list of changed files (use `git diff --name-status master` to get formatted list)

M       Registry/Registry.EM_COMMON
M       dyn_em/module_first_rk_step_part1.F
M       phys/module_sf_clm.F
M       phys/module_sf_noahdrv.F
M       phys/module_sf_urban.F
M       phys/module_surface_driver.F
M       phys/noahmp  (submodule)

TESTS CONDUCTED: 
1. Do mods fix problem? How can that be demonstrated, and was that test conducted?
2. Are the Jenkins tests all passing?

RELEASE NOTE: Include a stand-alone message suitable for the inclusion in the minor and annual releases. A publication citation is appropriate.


